### PR TITLE
Convert `Command` errors to `ClientError`

### DIFF
--- a/crates/ircnet/src/client/builder.rs
+++ b/crates/ircnet/src/client/builder.rs
@@ -1,7 +1,6 @@
 use super::autoresponders::{AutoResponder, AutoResponderSet};
-use super::commands::{Login, LoginError, LoginOutput, LoginParams};
+use super::commands::{Login, LoginOutput, LoginParams};
 use super::{Client, ClientError, ConnectionParams};
-use thiserror::Error;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
@@ -34,18 +33,10 @@ impl SessionBuilder {
         self
     }
 
-    pub async fn build(self) -> Result<(Client, LoginOutput), SessionBuildError> {
+    pub async fn build(self) -> Result<(Client, LoginOutput), ClientError> {
         let mut client = Client::connect(self.connect).await?;
         client.set_autoresponders(self.autoresponders);
-        let login_output = client.run(Login::new(self.login)).await??;
+        let login_output = client.run(Login::new(self.login)).await?;
         Ok((client, login_output))
     }
-}
-
-#[derive(Debug, Error)]
-pub enum SessionBuildError {
-    #[error(transparent)]
-    Client(#[from] ClientError),
-    #[error(transparent)]
-    Login(#[from] LoginError),
 }

--- a/crates/ircnet/src/client/commands/join.rs
+++ b/crates/ircnet/src/client/commands/join.rs
@@ -52,7 +52,8 @@ impl JoinCommand {
 //  - ERR_NEEDMOREPARAMS (461) ?
 
 impl Command for JoinCommand {
-    type Output = Result<JoinOutput, JoinError>;
+    type Output = JoinOutput;
+    type Error = JoinError;
 
     fn get_client_messages(&mut self) -> Vec<ClientMessage> {
         std::mem::take(&mut self.outgoing)
@@ -125,7 +126,7 @@ impl Command for JoinCommand {
         matches!(self.state, State::Done(_))
     }
 
-    fn get_output(&mut self) -> Self::Output {
+    fn get_output(&mut self) -> Result<JoinOutput, JoinError> {
         if let State::Done(ref mut r) = self.state {
             r.take()
                 .expect("get_output() should not be called more than once")

--- a/crates/ircnet/src/client/commands/login.rs
+++ b/crates/ircnet/src/client/commands/login.rs
@@ -77,7 +77,8 @@ impl Login {
 //      - ERR_SASLALREADY (907)
 
 impl Command for Login {
-    type Output = Result<LoginOutput, LoginError>;
+    type Output = LoginOutput;
+    type Error = LoginError;
 
     fn get_client_messages(&mut self) -> Vec<ClientMessage> {
         std::mem::take(&mut self.outgoing)
@@ -160,7 +161,7 @@ impl Command for Login {
         matches!(self.state, State::Done(_))
     }
 
-    fn get_output(&mut self) -> Self::Output {
+    fn get_output(&mut self) -> Result<LoginOutput, LoginError> {
         if let State::Done(ref mut r) = self.state {
             r.take()
                 .expect("get_output() should not be called more than once")

--- a/crates/ircnet/src/client/commands/mod.rs
+++ b/crates/ircnet/src/client/commands/mod.rs
@@ -29,9 +29,11 @@ use std::time::Duration;
 ///       `true`, call `get_output()` to get the result of the command, and
 ///       then discard the command.
 pub trait Command {
-    /// Information returned by the command upon completion, whether successful
-    /// or not
+    /// Information returned by the command upon successful completion
     type Output;
+
+    /// Type returned by the command upon failure
+    type Error: std::error::Error + Send + Sync + 'static;
 
     /// Returns outgoing messages to send back to the server.
     ///
@@ -85,5 +87,5 @@ pub trait Command {
     /// This method MUST only be called after `is_done()` returns true and MUST
     /// be called at most once.  If these preconditions are violated, the
     /// implementation MAY panic.
-    fn get_output(&mut self) -> Self::Output;
+    fn get_output(&mut self) -> Result<Self::Output, Self::Error>;
 }

--- a/crates/ircnet/src/client/mod.rs
+++ b/crates/ircnet/src/client/mod.rs
@@ -218,7 +218,8 @@ impl Client {
                 deadline = Some(Instant::now() + d);
             }
         }
-        Ok(cmd.get_output())
+        cmd.get_output()
+            .map_err(|e| ClientError::Command(Box::new(e)))
     }
 }
 
@@ -230,6 +231,8 @@ pub enum ClientError {
     Send(#[source] MessageCodecError),
     #[error("failed to receive message from server")]
     Recv(#[source] MessageCodecError),
+    #[error("command failed")]
+    Command(#[source] Box<dyn std::error::Error + Send + Sync>),
     #[error("connection terminated while running command")]
     Disconnect,
 }

--- a/crates/ircwatch/src/main.rs
+++ b/crates/ircwatch/src/main.rs
@@ -130,7 +130,7 @@ async fn run(args: Arguments) -> anyhow::Result<()> {
         args.channels
     };
     for chan in channels {
-        let output = client.run(JoinCommand::new(chan.clone())).await??;
+        let output = client.run(JoinCommand::new(chan.clone())).await?;
         report(&format!("[JOIN] Joined {chan}"));
         if let Some(topic) = output.topic {
             report(&format!(


### PR DESCRIPTION
Closes #79.